### PR TITLE
Add more slack channels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         LOGFIRE_BASE_URL: $LOGFIRE_BASE_URL
         GITHUB_WEBHOOK_SECRET: $GITHUB_WEBHOOK_SECRET
         SLACK_SIGNING_SECRET: $SLACK_SIGNING_SECRET
-        SLACK_CHANNEL_IDS: ${SLACK_CHANNEL_IDS:-[]}
+        SLACK_CHANNEL: ${SLACK_CHANNEL:-{}}
     healthcheck:
       test: python -c "import urllib.request as r; assert r.urlopen('http://localhost:8000/health').status == 200"
     depends_on:

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
         sync: false
       - key: SLACK_SIGNING_SECRET
         sync: false
-      - key: SLACK_CHANNEL_IDS
+      - key: SLACK_CHANNEL
         sync: false
       - key: CREATE_DATABASE
         value: "false"

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -7,6 +7,7 @@ from fastui import AnyComponent, FastUI
 from fastui import components as c
 from fastui.events import GoToEvent
 
+from .settings import settings
 from .shared import demo_page
 
 router = APIRouter()
@@ -20,6 +21,9 @@ This site demonstrates [Pydantic Logfire](https://docs.logfire.dev).
 
 You can use the sections below to see how different tasks are recorded by Logfire.
 """
+    slack_links = [
+        f'* [{channel_name}](/slack/{channel_id})' for channel_id, channel_name in settings.slack_channel.items()
+    ]
     return demo_page(
         c.Markdown(text=markdown),
         c.Div(
@@ -32,7 +36,7 @@ You can use the sections below to see how different tasks are recorded by Logfir
         c.Div(
             components=[
                 c.Heading(text='Slack Messages Archive', level=2),
-                c.Link(components=[c.Text(text='Logfire Slack')], on_click=GoToEvent(url='/slack')),
+                c.Markdown(text='\n'.join(slack_links)),
             ],
             class_name='border-top mt-3 pt-1',
         ),

--- a/src/webui/settings.py
+++ b/src/webui/settings.py
@@ -8,7 +8,7 @@ class Settings(GeneralSettings):
     tiling_server: str = 'http://localhost:8001'
     github_webhook_secret: SecretStr = 'test-github-secret'
     slack_signing_secret: SecretStr = 'test-slack-signing-secret'
-    slack_channel_ids: list[str] = ['']
+    slack_channel: dict[str, str] = {}  # mapping between Slack channel IDs and names
 
 
 settings = Settings()  # type: ignore

--- a/src/webui/slack.py
+++ b/src/webui/slack.py
@@ -9,10 +9,10 @@ from .shared import demo_page
 router = APIRouter()
 
 
-@router.get('', response_model=FastUI, response_model_exclude_none=True)
-async def read_messages(request: Request, db: Database):
+@router.get('/{channel_id}', response_model=FastUI, response_model_exclude_none=True)
+async def read_messages(request: Request, db: Database, channel_id: str):
     async with db.acquire() as conn:
-        messages = await get_root_slack_messages(conn)
+        messages = await get_root_slack_messages(conn, channel_id)
 
         text = ''
         for msg in messages:

--- a/src/webui/web_hooks.py
+++ b/src/webui/web_hooks.py
@@ -159,8 +159,8 @@ async def slack_events(request: Request, db: Database, openai_client: AsyncOpenA
         logfire.info('Received Slack event: {event}', event=event)
 
         # Only process messages from allowed channels
-        if (channel := event.get('channel')) not in settings.slack_channel_ids:
-            logfire.error('Invalid Slack channel: {channel}', channel=channel)
+        if (channel := event.get('channel')) not in settings.slack_channel:
+            logfire.info('Invalid Slack channel: {channel}', channel=channel)
             return {'message': 'Invalid Slack channel'}
 
         if event.get('type') == 'message' and event.get('subtype') is None:


### PR DESCRIPTION
Now we can configure demo project to receive messages from multiple slack messages. I have to add the `SLACK_CHANNEL` env variable to render. then we will receive messages from `logfire`, `pydantic`, `pydantic-ai` public channel. here is the config:

```{"C06EDRBSAH3": "Logfire", "C074GP90D8A": "Pydantic", "C083V7PMHHA": "Pydantic-AI"}```